### PR TITLE
Add detecting entering balls via current spikes in the intake motor

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/subsystems/IntakeSubsystem.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/lib/subsystems/IntakeSubsystem.java
@@ -1,17 +1,19 @@
 package org.firstinspires.ftc.teamcode.lib.subsystems;
 
-import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.robotcore.external.navigation.CurrentUnit;
 
 public class IntakeSubsystem extends SubsystemBase {
-    private final DcMotor spinMotor;
+    private static final double INTAKE_THRESHOLD = 1;
+    private final DcMotorEx spinMotor;
     private final Telemetry telemetry;
 
     public IntakeSubsystem(HardwareMap hardwareMap, Telemetry telemetry) {
-        spinMotor = hardwareMap.get(DcMotor.class, "intakeMotor");
+        spinMotor = hardwareMap.get(DcMotorEx.class, "intakeMotor");
         spinMotor.setDirection(DcMotorSimple.Direction.REVERSE);
         this.telemetry = telemetry;
     }
@@ -23,5 +25,12 @@ public class IntakeSubsystem extends SubsystemBase {
      */
     public void setPower(double power) {
         spinMotor.setPower(power);
+    }
+
+    /**
+     * @return true if the current spikes, indicating a ball is being intaken
+     */
+    public boolean ballIntaken() {
+        return spinMotor.getCurrent(CurrentUnit.AMPS) > INTAKE_THRESHOLD;
     }
 }


### PR DESCRIPTION
This is currently gated by a boolean constant that will switch us between using the color sensor and the current spike to detect entering balls. This is meant to be a backup in case the color sensor does not work.
